### PR TITLE
Normalize energy totals before computing conclusion summary

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.components import persistent_notification, recorder
 from homeassistant.components.recorder import statistics as recorder_statistics
 from homeassistant.components.recorder.models.statistics import StatisticMetaData
 from homeassistant.components.recorder.statistics import StatisticsRow
-from homeassistant.const import CONF_FILENAME
+from homeassistant.const import CONF_FILENAME, ENERGY_KILO_WATT_HOUR
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.config_entries import ConfigEntry
@@ -27,6 +27,12 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import dt as dt_util
+from homeassistant.util.unit_conversion import EnergyConverter
+
+try:  # pragma: no cover - dépend de la version de Home Assistant
+    from homeassistant.util.unit_conversion import UnitConversionError
+except ImportError:  # pragma: no cover - compatibilité anciennes versions
+    UnitConversionError = ValueError  # type: ignore[misc,assignment]
 
 from homeassistant.components.energy.data import async_get_manager
 
@@ -1906,7 +1912,8 @@ def _prepare_conclusion_summary(
     category_totals: dict[str, float] = {
         value: 0.0 for value in _CONCLUSION_CATEGORY_MAP.values()
     }
-    energy_unit: str | None = None
+    reference_unit = ENERGY_KILO_WATT_HOUR
+    energy_unit: str | None = reference_unit
     has_values = False
 
     for metric in metrics:
@@ -1918,14 +1925,22 @@ def _prepare_conclusion_summary(
         if total is None:
             continue
 
+        unit = _extract_unit(metadata.get(metric.statistic_id)).strip()
+
+        if unit and unit != reference_unit:
+            try:
+                total = EnergyConverter.convert(total, unit, reference_unit)
+            except (UnitConversionError, ValueError):
+                _LOGGER.warning(
+                    "Impossible de convertir la statistique %s de %s vers %s",
+                    metric.statistic_id,
+                    unit,
+                    reference_unit,
+                )
+                continue
+
         has_values = True
         category_totals[key] += total
-
-        if energy_unit:
-            continue
-        unit_candidate = _extract_unit(metadata.get(metric.statistic_id)).strip()
-        if unit_candidate:
-            energy_unit = unit_candidate
 
     if not has_values:
         return None

--- a/tests/test_conclusion_summary.py
+++ b/tests/test_conclusion_summary.py
@@ -1,0 +1,67 @@
+"""Tests for the conclusion summary helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+from homeassistant.const import ENERGY_KILO_WATT_HOUR
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from custom_components.energy_pdf_report import (  # noqa: E402  # pylint: disable=wrong-import-position
+    _prepare_conclusion_summary,
+    MetricDefinition,
+)
+
+
+def _metadata(unit: str):
+    return (0, {"unit_of_measurement": unit})
+
+
+def test_prepare_conclusion_summary_converts_mixed_energy_units():
+    metrics = [
+        MetricDefinition("Production solaire", "solar"),
+        MetricDefinition("Import réseau", "grid_in_wh"),
+        MetricDefinition("Export réseau", "grid_out_wh"),
+        MetricDefinition("Consommation appareils", "device"),
+        MetricDefinition("Charge batterie", "charge_wh"),
+        MetricDefinition("Décharge batterie", "discharge"),
+    ]
+
+    totals = {
+        "solar": 5.0,  # already in kWh
+        "grid_in_wh": 2000.0,  # Wh
+        "grid_out_wh": 500.0,  # Wh
+        "device": 4.0,  # kWh
+        "charge_wh": 1000.0,  # Wh
+        "discharge": 0.5,  # kWh
+    }
+
+    metadata = {
+        "solar": _metadata(ENERGY_KILO_WATT_HOUR),
+        "grid_in_wh": _metadata("Wh"),
+        "grid_out_wh": _metadata("Wh"),
+        "device": _metadata(ENERGY_KILO_WATT_HOUR),
+        "charge_wh": _metadata("Wh"),
+        "discharge": _metadata(ENERGY_KILO_WATT_HOUR),
+    }
+
+    summary = _prepare_conclusion_summary(metrics, totals, metadata)
+
+    assert summary is not None
+    assert summary.energy_unit == ENERGY_KILO_WATT_HOUR
+    assert summary.production == pytest.approx(5.0)
+    assert summary.imported == pytest.approx(2.0)
+    assert summary.exported == pytest.approx(0.5)
+    assert summary.consumption == pytest.approx(4.0)
+    assert summary.charge == pytest.approx(1.0)
+    assert summary.discharge == pytest.approx(0.5)
+    assert summary.direct == pytest.approx(3.5)
+    assert summary.indirect == pytest.approx(0.5)
+    assert summary.total_estimated_consumption == pytest.approx(6.0)
+    assert summary.untracked_consumption == pytest.approx(2.0)
+    assert summary.formatted["imported"].endswith(f" {ENERGY_KILO_WATT_HOUR}")
+    assert summary.formatted["untracked_consumption"].startswith("2.000")


### PR DESCRIPTION
## Summary
- convert conclusion metrics to a common kWh reference unit before aggregation
- log and skip statistics whose units cannot be converted
- add pytest coverage for mixed Wh and kWh energy totals

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd2c72b3dc8320a51e7d429ae2d6a1