### PR TITLE
Fix float aggregation in conclusion summary

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -1939,6 +1939,16 @@ def _prepare_conclusion_summary(
                 )
                 continue
 
+        try:
+            total = float(total)
+        except (TypeError, ValueError):
+            _LOGGER.warning(
+                "Valeur de statistique %s non convertible en flottant: %s",
+                metric.statistic_id,
+                total,
+            )
+            continue
+
         has_values = True
         category_totals[key] += total
 


### PR DESCRIPTION
## Summary
- ensure energy totals are converted to floats before aggregating the conclusion summary
- log and skip statistics whose totals cannot be converted to floats

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd3fb98a8c8320aed7f2d1b48d57d6