### PR TITLE
Expose generated PDF download link in notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ data:
   filename: "weekly_energy_report.pdf"
 ```
 
-Adjust the parameters to suit your environment or omit optional fields to rely on the configured defaults.
+Adjust the parameters to suit your environment or omit optional fields to rely on the configured defaults. When the generated PDF is stored under the Home Assistant `www` directory, the persistent notification now includes a direct download link.

--- a/custom_components/energy_pdf_report/README.md
+++ b/custom_components/energy_pdf_report/README.md
@@ -24,7 +24,7 @@ Le résumé met désormais en avant la consommation totale estimée (production 
 - `co2_enabled` *(optionnel)* : booléen permettant d'activer ou de désactiver la section CO₂ pour cet appel. Si le paramètre est absent, la valeur configurée dans les options de l'intégration est utilisée.
 - `price_enabled` *(optionnel)* : booléen permettant d'activer ou de désactiver la section coûts pour cet appel. Si le paramètre est absent, la valeur configurée dans les options de l'intégration est utilisée.
 
-Le fichier généré est également signalé via une notification persistante dans Home Assistant, qui mentionne le tableau de bord utilisé lorsque ce paramètre est précisé.
+Le fichier généré est également signalé via une notification persistante dans Home Assistant, qui mentionne le tableau de bord utilisé lorsque ce paramètre est précisé. Lorsque le rapport est enregistré dans un sous-dossier de `www`, la notification affiche désormais un lien direct de téléchargement.
 
 > ℹ️ Le nombre de statistiques indiqué dans le rapport correspond simplement aux identifiants uniques présents dans vos préférences du tableau de bord Énergie. L'intégration n'impose aucune limite : toutes les statistiques disponibles sont prises en compte.
 

--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -25,6 +25,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.config_entries import ConfigEntry
 
 from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers.network import async_get_url, NoURLAvailable
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import dt as dt_util
 
@@ -601,6 +602,37 @@ async def _async_handle_generate(hass: HomeAssistant, call: ServiceCall) -> None
         conclusion_summary_for_advice,
     )
 
+    readable_path = pdf_path
+    public_url: str | None = None
+    filename_label = Path(pdf_path).name
+
+    try:
+        resolved_pdf_path = Path(pdf_path)
+        if not resolved_pdf_path.is_absolute():
+            resolved_pdf_path = Path(hass.config.path(pdf_path))
+        resolved_pdf_path = resolved_pdf_path.resolve()
+        readable_path = str(resolved_pdf_path)
+        filename_label = resolved_pdf_path.name or filename_label
+
+        www_root = Path(hass.config.path("www")).resolve()
+        relative_pdf_path = resolved_pdf_path.relative_to(www_root)
+    except (OSError, ValueError):
+        relative_pdf_path = None
+    else:
+        base_url: str | None = None
+        try:
+            base_url = async_get_url(hass, prefer_external=True)
+        except (NoURLAvailable, HomeAssistantError):
+            try:
+                base_url = async_get_url(hass, prefer_external=False)
+            except (NoURLAvailable, HomeAssistantError):
+                base_url = None
+
+        if base_url:
+            public_url = f"{base_url.rstrip('/')}/local/{relative_pdf_path.as_posix()}"
+
+    url_for_message = public_url or readable_path
+
     message_lines = [
         translations.notification_line_period.format(
             start=display_start.date().isoformat(),
@@ -615,7 +647,13 @@ async def _async_handle_generate(hass: HomeAssistant, call: ServiceCall) -> None
             )
         )
 
-    message_lines.append(translations.notification_line_file.format(path=pdf_path))
+    message_lines.append(
+        translations.notification_line_file.format(
+            path=readable_path,
+            url=url_for_message,
+            filename=filename_label,
+        )
+    )
     message = "\n".join(message_lines)
     persistent_notification.async_create(
         hass,

--- a/custom_components/energy_pdf_report/translations.py
+++ b/custom_components/energy_pdf_report/translations.py
@@ -155,7 +155,7 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         notification_title="Rapport énergie",
         notification_line_period="Rapport énergie généré pour la période du {start} au {end}.",
         notification_line_dashboard="Tableau de bord : {dashboard}",
-        notification_line_file="Fichier : {path}",
+        notification_line_file="Fichier : [{filename}]({url}) – {path}",
     ),
     "en": ReportTranslations(
         language="en",
@@ -233,7 +233,7 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         notification_title="Energy report",
         notification_line_period="Energy report generated for {start} to {end}.",
         notification_line_dashboard="Dashboard: {dashboard}",
-        notification_line_file="File: {path}",
+        notification_line_file="File: [{filename}]({url}) – {path}",
     ),
     "nl": ReportTranslations(
         language="nl",
@@ -311,7 +311,7 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         notification_title="Energiarapport",
         notification_line_period="Energiarapport gegenereerd voor {start} tot {end}.",
         notification_line_dashboard="Dashboard: {dashboard}",
-        notification_line_file="Bestand: {path}",
+        notification_line_file="Bestand: [{filename}]({url}) – {path}",
     ),
 }
 


### PR DESCRIPTION
## Summary
- convert the generated PDF path into a public URL when possible and include it in notifications
- update translations so the notification renders a clickable download link for the report file
- document the new notification behaviour in both English and French READMEs

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e10b79fdb48320b929e20ce652bdaf