### PR TITLE
Add direct download link to generated report notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,5 @@ data:
 ```
 
 Adjust the parameters to suit your environment or omit optional fields to rely on the configured defaults.
+
+When the generated PDF is stored within Home Assistant's `www` directory (for example, `/config/www/reports`), the persistent notification created by the integration will include a direct download link so you can access the document from the Home Assistant interface.

--- a/custom_components/energy_pdf_report/translations.py
+++ b/custom_components/energy_pdf_report/translations.py
@@ -155,7 +155,7 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         notification_title="Rapport énergie",
         notification_line_period="Rapport énergie généré pour la période du {start} au {end}.",
         notification_line_dashboard="Tableau de bord : {dashboard}",
-        notification_line_file="Fichier : {path}",
+        notification_line_file="Fichier : [{filename}]({url}) – {path}",
     ),
     "en": ReportTranslations(
         language="en",
@@ -233,7 +233,7 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         notification_title="Energy report",
         notification_line_period="Energy report generated for {start} to {end}.",
         notification_line_dashboard="Dashboard: {dashboard}",
-        notification_line_file="File: {path}",
+        notification_line_file="File: [{filename}]({url}) – {path}",
     ),
     "nl": ReportTranslations(
         language="nl",
@@ -311,7 +311,7 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         notification_title="Energiarapport",
         notification_line_period="Energiarapport gegenereerd voor {start} tot {end}.",
         notification_line_dashboard="Dashboard: {dashboard}",
-        notification_line_file="Bestand: {path}",
+        notification_line_file="Bestand: [{filename}]({url}) – {path}",
     ),
 }
 


### PR DESCRIPTION
## Summary
- resolve generated report paths inside the www directory to a shareable Home Assistant URL
- update notification strings to expose a clickable download link and refresh documentation accordingly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e10e671400832093b44e7855e78ef9