### PR TITLE
Ensure config flow compatible with legacy cores

### DIFF
--- a/custom_components/energy_pdf_report/config_flow.py
+++ b/custom_components/energy_pdf_report/config_flow.py
@@ -133,8 +133,8 @@ def _build_schema(defaults: Mapping[str, Any]) -> vol.Schema:
     return vol.Schema(schema_dict)
 
 
-class EnergyPDFReportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Config flow for Energy PDF Report."""
+class _EnergyPDFReportConfigFlow(config_entries.ConfigFlow):
+    """Base config flow for Energy PDF Report."""
 
     VERSION = 1
 
@@ -209,6 +209,24 @@ class EnergyPDFReportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         self._reconfigure_entry = None
         return await self.async_step_user()
+
+
+try:
+    class EnergyPDFReportConfigFlow(  # type: ignore[misc]
+        _EnergyPDFReportConfigFlow, domain=DOMAIN
+    ):
+        """Config flow for Energy PDF Report (new-style signature)."""
+
+
+except TypeError:  # pragma: no cover - compat with older versions
+
+    class EnergyPDFReportConfigFlow(_EnergyPDFReportConfigFlow):
+        """Config flow for Energy PDF Report (legacy signature)."""
+
+        domain = DOMAIN
+
+
+ConfigFlow = EnergyPDFReportConfigFlow
 
 
 class EnergyPDFReportOptionsFlowHandler(config_entries.OptionsFlow):


### PR DESCRIPTION
## Summary
- refactor the config flow to use a compatibility base class
- provide both new-style and legacy ConfigFlow definitions while keeping the same interface

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1305a9a188320a045ec04d710e3a1