### PR TITLE
Define explicit ConfigFlow class for legacy compatibility

### DIFF
--- a/custom_components/energy_pdf_report/config_flow.py
+++ b/custom_components/energy_pdf_report/config_flow.py
@@ -133,8 +133,8 @@ def _build_schema(defaults: Mapping[str, Any]) -> vol.Schema:
     return vol.Schema(schema_dict)
 
 
-class EnergyPDFReportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Config flow for Energy PDF Report."""
+class _EnergyPDFReportConfigFlow(config_entries.ConfigFlow):
+    """Base config flow for Energy PDF Report."""
 
     VERSION = 1
 
@@ -209,6 +209,29 @@ class EnergyPDFReportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         self._reconfigure_entry = None
         return await self.async_step_user()
+
+
+try:
+    class EnergyPDFReportConfigFlow(  # type: ignore[misc]
+        _EnergyPDFReportConfigFlow, domain=DOMAIN
+    ):
+        """Config flow for Energy PDF Report (new-style signature)."""
+
+
+    class ConfigFlow(EnergyPDFReportConfigFlow):
+        """Expose the flow under the legacy ``ConfigFlow`` name."""
+
+
+except TypeError:  # pragma: no cover - compat with older versions
+
+    class EnergyPDFReportConfigFlow(_EnergyPDFReportConfigFlow):
+        """Config flow for Energy PDF Report (legacy signature)."""
+
+        domain = DOMAIN
+
+
+    class ConfigFlow(EnergyPDFReportConfigFlow):
+        """Expose the same functionality for pre-domain keyword cores."""
 
 
 class EnergyPDFReportOptionsFlowHandler(config_entries.OptionsFlow):


### PR DESCRIPTION
## Summary
- expose an explicit `ConfigFlow` class in both compatibility branches so legacy cores can discover the handler

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1305a9a188320a045ec04d710e3a1