### PR TITLE
Add download URL to energy PDF report notification

### DIFF
--- a/custom_components/energy_pdf_report/translations.py
+++ b/custom_components/energy_pdf_report/translations.py
@@ -75,6 +75,7 @@ class ReportTranslations:
     notification_title: str
     notification_line_period: str
     notification_line_dashboard: str
+    notification_line_download: str
     notification_line_file: str
 
 
@@ -155,6 +156,7 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         notification_title="Rapport énergie",
         notification_line_period="Rapport énergie généré pour la période du {start} au {end}.",
         notification_line_dashboard="Tableau de bord : {dashboard}",
+        notification_line_download="[Télécharger le rapport]({url})",
         notification_line_file="Fichier : {path}",
     ),
     "en": ReportTranslations(
@@ -233,6 +235,7 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         notification_title="Energy report",
         notification_line_period="Energy report generated for {start} to {end}.",
         notification_line_dashboard="Dashboard: {dashboard}",
+        notification_line_download="[Download the report]({url})",
         notification_line_file="File: {path}",
     ),
     "nl": ReportTranslations(
@@ -311,6 +314,7 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         notification_title="Energiarapport",
         notification_line_period="Energiarapport gegenereerd voor {start} tot {end}.",
         notification_line_dashboard="Dashboard: {dashboard}",
+        notification_line_download="[Rapport downloaden]({url})",
         notification_line_file="Bestand: {path}",
     ),
 }


### PR DESCRIPTION
## Summary
- add a helper that resolves an accessible download URL for generated reports
- include the download link in the persistent notification when available
- extend static translations with a dedicated download line string

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e141bed82483208cd19f45a8cbebdc