### PR TITLE
Localize AI fallback advice message

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -79,7 +79,7 @@ from .const import (
     SERVICE_GENERATE_REPORT,
     VALID_PERIODS,
 )
-from .ai_helper import FALLBACK_MESSAGE, generate_advice
+from .ai_helper import generate_advice, get_fallback_message
 from .pdf import EnergyPDFBuilder, TableConfig, _decorate_category
 
 from .translations import ReportTranslations, get_report_translations
@@ -1914,7 +1914,7 @@ def _build_pdf(
 
     advice_content = advice_text.strip() if advice_text else ""
     if not advice_content:
-        advice_content = FALLBACK_MESSAGE
+        advice_content = get_fallback_message(translations.language)
 
     builder.add_section_title(translations.advice_section_title)
     builder.add_paragraph(advice_content)


### PR DESCRIPTION
## Summary
- add localized fallback texts for AI advice responses in all supported languages and default to French when unknown
- ensure the PDF generation uses the language-aware fallback returned by the AI helper

## Testing
- python - <<'PY'


------
https://chatgpt.com/codex/tasks/task_e_68e173efebac8320899fdf50ae001591