### PR TITLE
Include language code in generated PDF filename

### DIFF
--- a/custom_components/energy_pdf_report/README.md
+++ b/custom_components/energy_pdf_report/README.md
@@ -34,7 +34,7 @@ Depuis la page **Paramètres → Appareils et services**, ouvrez l'intégration 
 
 - **Répertoire de sortie** : dossier utilisé pour stocker les rapports lorsqu'aucun répertoire n'est fourni au service.
 - **Période par défaut** : granularité (`day`, `week`, `month`) appliquée si l'appel au service ne précise pas de période.
-- **Modèle de nom de fichier** : patron utilisé pour générer automatiquement le nom du PDF lorsqu'aucun nom n'est fourni (variables disponibles : `{start}`, `{end}`, `{period}`).
+- **Modèle de nom de fichier** : patron utilisé pour générer automatiquement le nom du PDF lorsqu'aucun nom n'est fourni (variables disponibles : `{start}`, `{end}`, `{period}`, `{language}`).
 
 Ces options sont immédiatement prises en compte lors du prochain appel au service, sans nécessiter de redémarrage de Home Assistant.
 

--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -79,7 +79,7 @@ from .const import (
     SERVICE_GENERATE_REPORT,
     VALID_PERIODS,
 )
-from .ai_helper import FALLBACK_MESSAGE, generate_advice
+from .ai_helper import generate_advice, get_fallback_message
 from .pdf import EnergyPDFBuilder, TableConfig, _decorate_category
 
 from .translations import ReportTranslations, get_report_translations
@@ -1612,6 +1612,7 @@ def _build_pdf(
             "start": display_start.date().isoformat(),
             "end": display_end.date().isoformat(),
             "period": period,
+            "language": translations.language,
         }
 
         try:
@@ -1914,7 +1915,7 @@ def _build_pdf(
 
     advice_content = advice_text.strip() if advice_text else ""
     if not advice_content:
-        advice_content = FALLBACK_MESSAGE
+        advice_content = get_fallback_message(translations.language)
 
     builder.add_section_title(translations.advice_section_title)
     builder.add_paragraph(advice_content)

--- a/custom_components/energy_pdf_report/const.py
+++ b/custom_components/energy_pdf_report/const.py
@@ -11,7 +11,7 @@ DEFAULT_REPORT_TYPE = "week"
 
 VALID_REPORT_TYPES = VALID_PERIODS
 DEFAULT_OUTPUT_DIR = "www/energy_reports"
-DEFAULT_FILENAME_PATTERN = "energy_report_{start}_{end}.pdf"
+DEFAULT_FILENAME_PATTERN = "energy_report_{language}_{start}_{end}.pdf"
 DEFAULT_LANGUAGE = "fr"
 SUPPORTED_LANGUAGES: tuple[str, ...] = ("fr", "nl", "en")
 


### PR DESCRIPTION
## Summary
- append the report language to the default PDF filename pattern
- expose the language placeholder when formatting the automatic filename
- document the new `{language}` variable in the filename pattern options

## Testing
- python -m compileall custom_components/energy_pdf_report


------
https://chatgpt.com/codex/tasks/task_e_68e173efebac8320899fdf50ae001591