### PR TITLE
Add comparison section to energy PDF

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -83,7 +83,12 @@ from .const import (
     VALID_PERIODS,
 )
 from .ai_helper import generate_advice, get_fallback_message
-from .pdf import EnergyPDFBuilder, TableConfig, _decorate_category
+from .pdf import (
+    EnergyPDFBuilder,
+    TableConfig,
+    _decorate_category,
+    build_comparison_section,
+)
 
 from .translations import ReportTranslations, get_report_translations
 
@@ -1891,6 +1896,14 @@ def _build_pdf(
             primary.metadata,
         )
 
+    comparison_conclusion_summary: ConclusionSummary | None = None
+    if comparison is not None:
+        comparison_conclusion_summary = _prepare_conclusion_summary(
+            metrics,
+            comparison.totals,
+            comparison.metadata,
+        )
+
     summary_display_rows = list(summary_rows)
     summary_emphasize_rows: list[int] = list(range(len(summary_display_rows)))
 
@@ -2125,6 +2138,21 @@ def _build_pdf(
 
     builder.add_section_title(translations.advice_section_title)
     builder.add_paragraph(advice_content)
+
+    if comparison is not None:
+        comparison_table = build_comparison_section(
+            translations,
+            metrics,
+            primary,
+            comparison,
+            primary_label=primary.label,
+            comparison_label=comparison.label,
+            primary_summary=conclusion_summary,
+            comparison_summary=comparison_conclusion_summary,
+        )
+
+        builder.add_section_title(translations.comparison_section_title)
+        builder.add_table(comparison_table)
 
     builder.add_footer(translations.footer_path.format(path=file_path))
 

--- a/custom_components/energy_pdf_report/translations.py
+++ b/custom_components/energy_pdf_report/translations.py
@@ -51,6 +51,19 @@ class ReportTranslations:
     co2_savings_label: str
     co2_balance_sentence: str
     co2_sensor_labels: Mapping[str, str]
+    comparison_section_title: str
+    comparison_table_title: str
+    comparison_header_category: str
+    comparison_header_difference: str
+    comparison_header_variation: str
+    comparison_consumption_label: str
+    comparison_production_label: str
+    comparison_import_label: str
+    comparison_export_label: str
+    comparison_self_consumption_label: str
+    comparison_expense_label: str
+    comparison_income_label: str
+    comparison_co2_label: str
     conclusion_title: str
     conclusion_overview_without_battery: str
     conclusion_overview_with_battery: str
@@ -132,6 +145,19 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
             "co2_savings": "Économies solaire (autoconsommation)",
 
         },
+        comparison_section_title="Comparaison de périodes",
+        comparison_table_title="Comparaison synthétique",
+        comparison_header_category="Catégorie",
+        comparison_header_difference="Différence",
+        comparison_header_variation="Variation",
+        comparison_consumption_label="Consommation",
+        comparison_production_label="Production",
+        comparison_import_label="Import réseau",
+        comparison_export_label="Export réseau",
+        comparison_self_consumption_label="Autoconsommation",
+        comparison_expense_label="Dépenses",
+        comparison_income_label="Revenus",
+        comparison_co2_label="CO₂",
         conclusion_title="Conclusion",
         conclusion_overview_without_battery="Sur la période, la production solaire atteint {production} dont {direct} autoconsommés directement. Les importations réseau totalisent {imported} tandis que {exported} ont été réinjectés, pour une consommation des appareils de {consumption}. La consommation totale estimée atteint {total_consumption} dont {untracked_consumption} non suivie.",
         conclusion_overview_with_battery="Sur la période, la production solaire atteint {production} : {direct} ont été autoconsommés directement et {indirect} via la batterie. Les importations réseau totalisent {imported} tandis que {exported} ont été réinjectés, pour une consommation des appareils de {consumption}. La consommation totale estimée atteint {total_consumption} dont {untracked_consumption} non suivie.",
@@ -211,6 +237,19 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
             "co2_savings": "Solar self-consumption savings",
 
         },
+        comparison_section_title="Period comparison",
+        comparison_table_title="Comparison overview",
+        comparison_header_category="Category",
+        comparison_header_difference="Difference",
+        comparison_header_variation="Change",
+        comparison_consumption_label="Consumption",
+        comparison_production_label="Production",
+        comparison_import_label="Grid import",
+        comparison_export_label="Grid export",
+        comparison_self_consumption_label="Self-consumption",
+        comparison_expense_label="Expenses",
+        comparison_income_label="Income",
+        comparison_co2_label="CO₂",
         conclusion_title="Conclusion",
         conclusion_overview_without_battery="Over the period, solar production reached {production} with {direct} consumed directly. Grid imports totalled {imported} while {exported} were sent back, and devices used {consumption}. Estimated total consumption reached {total_consumption} with {untracked_consumption} untracked.",
         conclusion_overview_with_battery="Over the period, solar production reached {production}: {direct} were consumed directly and {indirect} via the battery. Grid imports totalled {imported} while {exported} were sent back, and devices used {consumption}. Estimated total consumption reached {total_consumption} with {untracked_consumption} untracked.",
@@ -290,6 +329,19 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
             "co2_savings": "Zonnebesparing (eigen verbruik)",
 
         },
+        comparison_section_title="Periodevergelijking",
+        comparison_table_title="Vergelijkingsoverzicht",
+        comparison_header_category="Categorie",
+        comparison_header_difference="Verschil",
+        comparison_header_variation="Verandering",
+        comparison_consumption_label="Verbruik",
+        comparison_production_label="Productie",
+        comparison_import_label="Netimport",
+        comparison_export_label="Netexport",
+        comparison_self_consumption_label="Eigen verbruik",
+        comparison_expense_label="Kosten",
+        comparison_income_label="Opbrengsten",
+        comparison_co2_label="CO₂",
         conclusion_title="Conclusie",
         conclusion_overview_without_battery="In de periode bedroeg de zonneproductie {production} waarvan {direct} direct werd zelfverbruikt. Netimport kwam uit op {imported} terwijl {exported} werd teruggeleverd en toestellen verbruikten {consumption}. De geschatte totale consumptie bedraagt {total_consumption}, waarvan {untracked_consumption} niet gevolgd.",
         conclusion_overview_with_battery="In de periode bedroeg de zonneproductie {production}: {direct} werd rechtstreeks verbruikt en {indirect} via de batterij. Netimport bedroeg {imported} terwijl {exported} werd teruggeleverd en toestellen verbruikten {consumption}. De geschatte totale consumptie bedraagt {total_consumption}, waarvan {untracked_consumption} niet gevolgd.",


### PR DESCRIPTION
## Summary
- add a helper to aggregate key metrics across two periods and build the comparison table for the PDF
- extend PDF generation to render the new period comparison section when comparison data is available
- translate the comparison section title, headers, and row labels in French, English, and Dutch

## Testing
- python -m compileall custom_components/energy_pdf_report

------
https://chatgpt.com/codex/tasks/task_e_68e265e9ff48832085f9f1f560ebfc68