### PR TITLE
Refine comparison breakdown and conclusion insights

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -2079,6 +2079,10 @@ def _build_pdf(
             comparison_summary=comparison_conclusion_summary,
         )
 
+        comparison_table.column_widths = builder.compute_column_widths(
+            (0.32, 0.22, 0.22, 0.12, 0.12)
+        )
+
         builder.add_section_title(translations.comparison_section_title)
         builder.add_table(comparison_table)
 
@@ -2087,6 +2091,16 @@ def _build_pdf(
 
         overview_text = _render_conclusion_overview(translations, conclusion_summary)
         builder.add_paragraph(overview_text)
+
+        if comparison_conclusion_summary and comparison is not None:
+            insight_text = _render_comparison_conclusion_insight(
+                translations,
+                conclusion_summary,
+                comparison_conclusion_summary,
+                comparison.label,
+            )
+            if insight_text:
+                builder.add_paragraph(insight_text)
 
         formatted_values = conclusion_summary.formatted
         table_rows: list[tuple[str, str]] = [
@@ -2356,6 +2370,43 @@ def _render_conclusion_overview(
     )
 
 
+def _render_comparison_conclusion_insight(
+    translations: ReportTranslations,
+    primary_summary: ConclusionSummary,
+    comparison_summary: ConclusionSummary,
+    comparison_label: str,
+) -> str:
+    """Construire un texte de synthèse sur l'écart avec la période comparée."""
+
+    energy_unit = (
+        primary_summary.energy_unit or comparison_summary.energy_unit or ""
+    )
+
+    total_delta_value = (
+        primary_summary.total_estimated_consumption
+        - comparison_summary.total_estimated_consumption
+    )
+    import_delta_value = primary_summary.imported - comparison_summary.imported
+    export_delta_value = primary_summary.exported - comparison_summary.exported
+
+    total_delta = _format_signed_with_unit(total_delta_value, energy_unit)
+    import_delta = _format_signed_with_unit(import_delta_value, energy_unit)
+    export_delta = _format_signed_with_unit(export_delta_value, energy_unit)
+
+    total_variation = _format_percentage_delta(
+        primary_summary.total_estimated_consumption,
+        comparison_summary.total_estimated_consumption,
+    )
+
+    return translations.conclusion_comparison_insight.format(
+        label=comparison_label,
+        total_delta=total_delta,
+        total_variation=total_variation,
+        import_delta=import_delta,
+        export_delta=export_delta,
+    )
+
+
 def _compose_conclusion_prompt(
     translations: ReportTranslations, summary: ConclusionSummary | None
 ) -> str:
@@ -2471,6 +2522,32 @@ def _format_with_unit(value: float, unit: str | None) -> str:
 
     formatted = _format_number(value)
     return f"{formatted} {unit}".strip() if unit else formatted
+
+
+def _format_signed_number(value: float) -> str:
+    """Formater un nombre en ajoutant explicitement le signe positif."""
+
+    formatted = _format_number(value)
+    if value > 0:
+        return f"+{formatted}"
+    return formatted
+
+
+def _format_signed_with_unit(value: float, unit: str | None) -> str:
+    """Formater un écart numérique avec son unité."""
+
+    formatted = _format_signed_number(value)
+    return f"{formatted} {unit}".strip() if unit else formatted
+
+
+def _format_percentage_delta(current: float, baseline: float) -> str:
+    """Formater une variation en pourcentage entre deux valeurs."""
+
+    if abs(baseline) < 1e-9:
+        return "—"
+
+    delta = ((current - baseline) / baseline) * 100
+    return f"{_format_signed_number(delta)} %"
 
 
 __all__ = ["async_setup", "async_setup_entry", "async_unload_entry"]

--- a/custom_components/energy_pdf_report/pdf.py
+++ b/custom_components/energy_pdf_report/pdf.py
@@ -700,6 +700,10 @@ def _aggregate_comparison_values(
         key: None
         for key in (
             "consumption",
+            "consumption_water",
+            "consumption_gas",
+            "battery_charge",
+            "battery_discharge",
             "total_estimated_consumption",
             "untracked_consumption",
             "device_consumption",
@@ -783,8 +787,27 @@ def _classify_metric_category(category: str) -> set[str]:
 
     result: set[str] = set()
 
-    if "consommation" in lowered or "charge" in lowered:
+    battery_related = "batter" in lowered
+    discharge_keywords = ("décharge", "decharge", "discharge", "unload")
+    charge_keywords = ("charge", "charging", "load")
+
+    if battery_related and any(keyword in lowered for keyword in discharge_keywords):
+        result.add("battery_discharge")
+    if battery_related and any(keyword in lowered for keyword in charge_keywords):
+        if not any(keyword in lowered for keyword in discharge_keywords):
+            result.add("battery_charge")
+
+    if "consommation" in lowered or "consumption" in lowered:
         result.add("consumption")
+
+    water_keywords = ("eau", "water", "wasser", "acqua")
+    if any(keyword in lowered for keyword in water_keywords):
+        result.add("consumption_water")
+
+    gas_keywords = ("gaz", "gas", "gás", "gaso", "fioul", "mazout", "fuel", "oil")
+    if any(keyword in lowered for keyword in gas_keywords):
+        result.add("consumption_gas")
+
     if "production" in lowered:
         result.add("production")
     if "import" in lowered:
@@ -877,7 +900,6 @@ def _format_signed(value: float) -> str:
 
 
 _COMPARISON_ROWS: Tuple[Tuple[str, str, str | None], ...] = (
-    ("consumption", "comparison_consumption_label", None),
     (
         "total_estimated_consumption",
         "comparison_total_estimated_consumption_label",
@@ -888,10 +910,14 @@ _COMPARISON_ROWS: Tuple[Tuple[str, str, str | None], ...] = (
     ("production", "comparison_production_label", None),
     ("import", "comparison_import_label", None),
     ("export", "comparison_export_label", None),
+    ("battery_charge", "comparison_battery_charge_label", None),
+    ("battery_discharge", "comparison_battery_discharge_label", None),
     ("self_consumption", "comparison_self_consumption_label", None),
     ("expenses", "comparison_expense_label", None),
     ("income", "comparison_income_label", None),
     ("co2", "comparison_co2_label", "kgCO₂e"),
+    ("consumption_water", "comparison_water_consumption_label", None),
+    ("consumption_gas", "comparison_gas_consumption_label", None),
 )
 
 

--- a/custom_components/energy_pdf_report/translations.py
+++ b/custom_components/energy_pdf_report/translations.py
@@ -57,6 +57,8 @@ class ReportTranslations:
     comparison_header_difference: str
     comparison_header_variation: str
     comparison_consumption_label: str
+    comparison_battery_charge_label: str
+    comparison_battery_discharge_label: str
     comparison_total_estimated_consumption_label: str
     comparison_untracked_consumption_label: str
     comparison_device_consumption_label: str
@@ -67,6 +69,8 @@ class ReportTranslations:
     comparison_expense_label: str
     comparison_income_label: str
     comparison_co2_label: str
+    comparison_water_consumption_label: str
+    comparison_gas_consumption_label: str
     conclusion_title: str
     conclusion_overview_without_battery: str
     conclusion_overview_with_battery: str
@@ -81,6 +85,7 @@ class ReportTranslations:
     conclusion_row_total_consumption_label: str
     conclusion_row_untracked_consumption_label: str
     conclusion_hint: str
+    conclusion_comparison_insight: str
     advice_section_title: str
     footer_path: str
     footer_page: str
@@ -154,6 +159,8 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         comparison_header_difference="Différence",
         comparison_header_variation="Variation",
         comparison_consumption_label="Consommation",
+        comparison_battery_charge_label="Charge batterie",
+        comparison_battery_discharge_label="Décharge batterie",
         comparison_total_estimated_consumption_label="Consommation totale estimée",
         comparison_untracked_consumption_label="Consommation non suivie",
         comparison_device_consumption_label="Consommation appareils",
@@ -164,6 +171,8 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         comparison_expense_label="Dépenses",
         comparison_income_label="Revenus",
         comparison_co2_label="CO₂",
+        comparison_water_consumption_label="Consommation eau",
+        comparison_gas_consumption_label="Consommation gaz / mazout",
         conclusion_title="Conclusion",
         conclusion_overview_without_battery="Sur la période, la production solaire atteint {production} dont {direct} autoconsommés directement. Les importations réseau totalisent {imported} tandis que {exported} ont été réinjectés, pour une consommation des appareils de {consumption}. La consommation totale estimée atteint {total_consumption} dont {untracked_consumption} non suivie.",
         conclusion_overview_with_battery="Sur la période, la production solaire atteint {production} : {direct} ont été autoconsommés directement et {indirect} via la batterie. Les importations réseau totalisent {imported} tandis que {exported} ont été réinjectés, pour une consommation des appareils de {consumption}. La consommation totale estimée atteint {total_consumption} dont {untracked_consumption} non suivie.",
@@ -178,6 +187,7 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         conclusion_row_total_consumption_label="Consommation totale estimée",
         conclusion_row_untracked_consumption_label="Consommation non suivie",
         conclusion_hint="Pour approfondir l'évolution temporelle et comparer les périodes, référez-vous au tableau de bord EcoPilot.",
+        conclusion_comparison_insight="Écart vs {label} : consommation totale estimée {total_delta} ({total_variation}), import réseau {import_delta}, export réseau {export_delta}.",
         advice_section_title="Les conseils personnalisés EcoPilot",
         footer_path="Chemin du fichier : {path}",
         footer_page="Page {current} sur {total}",
@@ -249,6 +259,8 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         comparison_header_difference="Difference",
         comparison_header_variation="Change",
         comparison_consumption_label="Consumption",
+        comparison_battery_charge_label="Battery charge",
+        comparison_battery_discharge_label="Battery discharge",
         comparison_total_estimated_consumption_label="Estimated total consumption",
         comparison_untracked_consumption_label="Untracked consumption",
         comparison_device_consumption_label="Device consumption",
@@ -259,6 +271,8 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         comparison_expense_label="Expenses",
         comparison_income_label="Income",
         comparison_co2_label="CO₂",
+        comparison_water_consumption_label="Water consumption",
+        comparison_gas_consumption_label="Gas / fuel consumption",
         conclusion_title="Conclusion",
         conclusion_overview_without_battery="Over the period, solar production reached {production} with {direct} consumed directly. Grid imports totalled {imported} while {exported} were sent back, and devices used {consumption}. Estimated total consumption reached {total_consumption} with {untracked_consumption} untracked.",
         conclusion_overview_with_battery="Over the period, solar production reached {production}: {direct} were consumed directly and {indirect} via the battery. Grid imports totalled {imported} while {exported} were sent back, and devices used {consumption}. Estimated total consumption reached {total_consumption} with {untracked_consumption} untracked.",
@@ -273,6 +287,7 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         conclusion_row_total_consumption_label="Estimated total consumption",
         conclusion_row_untracked_consumption_label="Untracked consumption",
         conclusion_hint="For deeper time-based analysis and comparisons, refer to EcoPilot's dashboard.",
+        conclusion_comparison_insight="Gap vs {label}: estimated total consumption {total_delta} ({total_variation}), grid import {import_delta}, grid export {export_delta}.",
         advice_section_title="EcoPilot tailored advice",
         footer_path="File path: {path}",
         footer_page="Page {current} of {total}",
@@ -344,6 +359,8 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         comparison_header_difference="Verschil",
         comparison_header_variation="Verandering",
         comparison_consumption_label="Verbruik",
+        comparison_battery_charge_label="Batterij laden",
+        comparison_battery_discharge_label="Batterij ontladen",
         comparison_total_estimated_consumption_label="Geschat totaalverbruik",
         comparison_untracked_consumption_label="Niet-opgevolgd verbruik",
         comparison_device_consumption_label="Apparaatverbruik",
@@ -354,6 +371,8 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         comparison_expense_label="Kosten",
         comparison_income_label="Opbrengsten",
         comparison_co2_label="CO₂",
+        comparison_water_consumption_label="Waterverbruik",
+        comparison_gas_consumption_label="Gas/mazoutverbruik",
         conclusion_title="Conclusie",
         conclusion_overview_without_battery="In de periode bedroeg de zonneproductie {production} waarvan {direct} direct werd zelfverbruikt. Netimport kwam uit op {imported} terwijl {exported} werd teruggeleverd en toestellen verbruikten {consumption}. De geschatte totale consumptie bedraagt {total_consumption}, waarvan {untracked_consumption} niet gevolgd.",
         conclusion_overview_with_battery="In de periode bedroeg de zonneproductie {production}: {direct} werd rechtstreeks verbruikt en {indirect} via de batterij. Netimport bedroeg {imported} terwijl {exported} werd teruggeleverd en toestellen verbruikten {consumption}. De geschatte totale consumptie bedraagt {total_consumption}, waarvan {untracked_consumption} niet gevolgd.",
@@ -368,6 +387,7 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         conclusion_row_total_consumption_label="Geschatte totale consumptie",
         conclusion_row_untracked_consumption_label="Niet gevolgde consumptie",
         conclusion_hint="Raadpleeg het Energiadashboard van EcoPilot voor een diepere tijdsanalyse en vergelijkingen.",
+        conclusion_comparison_insight="Verschil t.o.v. {label}: geschat totaalverbruik {total_delta} ({total_variation}), netimport {import_delta}, netexport {export_delta}.",
         advice_section_title="EcoPilot persoonlijk advies",
         footer_path="Bestandspad: {path}",
         footer_page="Pagina {current} van {total}",


### PR DESCRIPTION
## Summary
- split the aggregated consumption comparison row into dedicated battery, water, and gas entries and adjust the comparison table layout for better readability
- add localized strings for the new comparison rows and the conclusion insight text
- surface a comparison insight paragraph in the conclusion when a reference period is provided

## Testing
- python -m compileall custom_components/energy_pdf_report

------
https://chatgpt.com/codex/tasks/task_e_68e27847f050832092e3afb4181bb1f1