### PR TITLE
Use HTML link for persistent notification download

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -830,7 +830,8 @@ async def _async_handle_generate(hass: HomeAssistant, call: ServiceCall) -> None
 
     if download_url:
         message_lines.append(
-            translations.notification_line_download.format(url=download_url)
+            f'<a href="{download_url}" target="_blank">'
+            f"{translations.notification_line_download}</a>"
         )
 
     message_lines.append(translations.notification_line_file.format(path=pdf_path))

--- a/custom_components/energy_pdf_report/translations.py
+++ b/custom_components/energy_pdf_report/translations.py
@@ -204,7 +204,7 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         notification_title="Rapport énergie",
         notification_line_period="Rapport énergie généré pour la période du {start} au {end}.",
         notification_line_dashboard="Tableau de bord : {dashboard}",
-        notification_line_download="[Télécharger le rapport]({url})",
+        notification_line_download="📄 Télécharger le rapport",
         notification_line_file="Fichier : {path}",
     ),
     "en": ReportTranslations(
@@ -310,7 +310,7 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         notification_title="Energy report",
         notification_line_period="Energy report generated for {start} to {end}.",
         notification_line_dashboard="Dashboard: {dashboard}",
-        notification_line_download="[Download the report]({url})",
+        notification_line_download="📄 Download the report",
         notification_line_file="File: {path}",
     ),
     "nl": ReportTranslations(
@@ -416,7 +416,7 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         notification_title="Energiarapport",
         notification_line_period="Energiarapport gegenereerd voor {start} tot {end}.",
         notification_line_dashboard="Dashboard: {dashboard}",
-        notification_line_download="[Rapport downloaden]({url})",
+        notification_line_download="📄 Rapport downloaden",
         notification_line_file="Bestand: {path}",
     ),
 }


### PR DESCRIPTION
## Summary
- render the persistent notification download link as an HTML anchor that opens in a new tab
- update localized download link labels to drop Markdown formatting and reuse them inside the HTML anchor

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6514947dc8320a84d23a44e674388