### PR TITLE
Add config schema for energy_pdf_report integration

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -100,6 +100,8 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
 _RECORDER_METADATA_REQUIRES_HASS: bool | None = None
 
 


### PR DESCRIPTION
## Summary
- declare a config schema for the integration that only supports config entries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e678c8a02c8320861b6304d204e148