### PR TITLE
Register options flow handler for UI settings

### DIFF
--- a/custom_components/energy_pdf_report/config_flow.py
+++ b/custom_components/energy_pdf_report/config_flow.py
@@ -241,3 +241,13 @@ class EnergyPDFReportOptionsFlowHandler(config_entries.OptionsFlow):
 async def async_get_options_flow(config_entry: config_entries.ConfigEntry):
     """Retourner le gestionnaire d’options."""
     return EnergyPDFReportOptionsFlowHandler(config_entry)
+
+
+# Compatibilité : enregistrer explicitement le flow d'options lorsque
+# l'API moderne est disponible (Home Assistant 2024.8+). Cela garantit que
+# l'interface affiche l'icône "paramètres" même si la découverte automatique
+# échoue sur certaines versions.
+if hasattr(config_entries, "OPTIONS_FLOW") and hasattr(
+    config_entries.OPTIONS_FLOW, "register"
+):
+    config_entries.OPTIONS_FLOW.register(DOMAIN)(EnergyPDFReportOptionsFlowHandler)


### PR DESCRIPTION
## Summary
- explicitly register the options flow handler when Home Assistant exposes the OPTIONS_FLOW registry
- ensure the integration still exposes its configuration schema so the settings gear appears in the UI

## Testing
- python -m compileall custom_components/energy_pdf_report/config_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68ea81959a548320bda1f2eeef5adb52