### PR TITLE
Prefer recorder change totals before sum fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Generate beautifully formatted PDF summaries of your Home Assistant Energy Dashb
 
 - Home Assistant with the Energy Dashboard configured and recording statistics for the entities you want to include.
 - Recorder enabled so historical statistics can be fetched for the requested period(s).
+- Price and CO₂ sensors must expose long-term statistics with a daily `change` column. In practice, use
+  entities whose `state_class` is `total_increasing` (or a `utility_meter`/Energy Dashboard helper built from
+  such sensors) so that Home Assistant records the cumulative cost or emission total that the integration can
+  sum over the selected period. If Home Assistant reports a negative `change` while the counter resets, the
+  integration keeps the absolute delta; it only falls back to a positive `sum` when no usable `change`
+  value is available, so the PDF never displays negative totals for well-behaved counters.
 - (Optional) An OpenAI API key if you want to enable the advisor section of the report.
 
 ## Installation via HACS

--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -6,6 +6,7 @@ import calendar
 
 import inspect
 import logging
+import math
 import secrets
 import string
 from collections import defaultdict
@@ -1609,6 +1610,47 @@ async def _collect_statistics(
     return StatisticsResult(stats_map, metadata)
 
 
+def _coerce_stat_value(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_statistic_value(value: Any) -> float | None:
+    """Convertir une valeur de statistique en flottant exploitable."""
+
+    coerced = _coerce_stat_value(value)
+    if coerced is None:
+        return None
+
+    if isinstance(coerced, float) and math.isnan(coerced):
+        return None
+
+    return coerced
+
+
+def _select_counter_total(row: StatisticsRow) -> float | None:
+    """Choisir la contribution quotidienne à partir d'une ligne de statistiques."""
+
+    change_value = _normalize_statistic_value(row.get("change"))
+    if change_value is not None:
+        if change_value >= 0:
+            return change_value
+        return abs(change_value)
+
+    sum_value = _normalize_statistic_value(row.get("sum"))
+    if sum_value is None:
+        return None
+
+    if sum_value >= 0:
+        return sum_value
+
+    return abs(sum_value)
+
+
 async def _collect_co2_statistics(
     hass: HomeAssistant,
     start: datetime,
@@ -1638,7 +1680,7 @@ async def _collect_co2_statistics(
         statistic_ids,
         "day",
         None,
-        {"change"},
+        {"change", "sum"},
     )
 
     for entity_id in statistic_ids:
@@ -1649,11 +1691,11 @@ async def _collect_co2_statistics(
         total = 0.0
         has_sum = False
         for row in rows:
-            change_value = row.get("change")
-            if change_value is None:
+            contribution = _select_counter_total(row)
+            if contribution is None:
                 continue
             has_sum = True
-            total += float(change_value)
+            total += contribution
 
         if has_sum:
             definition = entity_map[entity_id]
@@ -1691,7 +1733,7 @@ async def _collect_price_statistics(
         statistic_ids,
         "day",
         None,
-        {"change"},
+        {"change", "sum"},
     )
 
     for entity_id in statistic_ids:
@@ -1702,11 +1744,11 @@ async def _collect_price_statistics(
         total = 0.0
         has_sum = False
         for row in rows:
-            change_value = row.get("change")
-            if change_value is None:
+            contribution = _select_counter_total(row)
+            if contribution is None:
                 continue
             has_sum = True
-            total += float(change_value)
+            total += contribution
 
         if has_sum:
             definition = entity_map[entity_id]


### PR DESCRIPTION
## Summary
- prioritize recorder `change` values (using their absolute when negative) when aggregating CO₂ and price counters so counters that never reset stay accurate
- only fall back to a positive `sum` when no usable `change` exists, preventing runaway totals on electricity CO₂ sensors
- clarify the README to describe the new precedence between `change` and `sum`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea8a8e58b08320aa25026fe964ae20