### PR TITLE
Use decimal totals for CO₂ and price statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ Generate beautifully formatted PDF summaries of your Home Assistant Energy Dashb
 
 - Home Assistant with the Energy Dashboard configured and recording statistics for the entities you want to include.
 - Recorder enabled so historical statistics can be fetched for the requested period(s).
+- Price and CO₂ sensors must expose long-term statistics with a daily `change` column. In practice, use
+  entities whose `state_class` is `total_increasing` (or a `utility_meter`/Energy Dashboard helper built from
+  such sensors) so that Home Assistant records the cumulative cost or emission total that the integration can
+  sum over the selected period. The integration keeps a positive `change` when available, but when Home
+  Assistant reports a non-positive `change` during a reset it prefers the positive `sum` provided by the
+  recorder (falling back to the absolute delta only if both are missing) so the PDF remains accurate for
+  counters that reset or drift backwards.
+- Very small CO₂ and price variations (for example `0.039` kgCO₂e of water) are accumulated with decimal
+  arithmetic, so the integration never rounds them before computing the period total, and they are rendered
+  without rounding so they remain `0.039` instead of `0.04` in the PDF tables.
 - (Optional) An OpenAI API key if you want to enable the advisor section of the report.
 
 ## Installation via HACS
@@ -64,6 +74,15 @@ Use the `energy_pdf_report.generate` service from **Developer Tools → Services
 | `compare` | Boolean | Enable comparison with a secondary period. Requires `compare_start_date` and `compare_end_date`. |
 | `compare_start_date` | Date | First day of the comparison range when `compare` is true. |
 | `compare_end_date` | Date | Last day of the comparison range when `compare` is true. |
+
+### How period boundaries are applied
+
+The integration always treats `start_date` and `end_date` as inclusive calendar
+days. Internally it converts the end of the range to an exclusive timestamp
+(`end_date + 1 day`) before querying Home Assistant statistics. The same
+normalized start/end timestamps are reused for energy metrics, price totals, and
+CO₂ totals, so every section of the PDF covers exactly the same days regardless
+of the data source.
 
 Example service call:
 

--- a/custom_components/energy_pdf_report/README.md
+++ b/custom_components/energy_pdf_report/README.md
@@ -65,6 +65,12 @@ Use the `energy_pdf_report.generate` service from **Developer Tools → Services
 | `compare_start_date` | Date | First day of the comparison range when `compare` is true. |
 | `compare_end_date` | Date | Last day of the comparison range when `compare` is true. |
 
+### How the `period` field is used
+
+- **Default range selection** – When `start_date` or `end_date` is omitted, the integration expands the selected `period` into an inclusive date window before fetching energy, price, and CO₂ statistics.
+- **Recorder granularity** – The same `period` drives the statistic bucket (`hour` or `day`) requested from the recorder so that the totals match the Energy Dashboard view for that range.
+- **File naming** – The resolved `period` value is injected into the filename pattern, allowing you to build names such as `energy_report_week_2024-10-04_2024-10-10.pdf` automatically.
+
 Example service call:
 
 ```yaml
@@ -109,6 +115,7 @@ mode: single
 ## Troubleshooting
 
 - Ensure the recorder includes statistics for every entity referenced by the integration; missing statistics will prevent the related rows from appearing.
+- When tracking very small CO₂ or price counters (for example water emissions around `0.039` kgCO₂e per day), the integration accumulates their daily statistics with decimal arithmetic and the PDF prints those values without rounding so they can be re-used in downstream calculations.
 - If the report generation service fails, check **Settings → System → Logs** for detailed error messages.
 - When the AI advisor is enabled, verify that your OpenAI API key is valid and that outbound HTTPS requests are permitted from your Home Assistant host.
 

--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -11,6 +11,7 @@ import string
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta, tzinfo
+from decimal import Decimal, InvalidOperation
 
 from pathlib import Path
 from typing import Any, Iterable, Mapping, TYPE_CHECKING
@@ -702,7 +703,7 @@ async def _async_handle_generate(hass: HomeAssistant, call: ServiceCall) -> None
     if price_enabled:
         price_definitions = _build_price_sensor_definitions(options)
 
-    co2_totals: dict[str, float] = {}
+    co2_totals: dict[str, Decimal] = {}
     if co2_definitions:
         co2_totals = await _collect_co2_statistics(
             hass,
@@ -711,7 +712,7 @@ async def _async_handle_generate(hass: HomeAssistant, call: ServiceCall) -> None
             co2_definitions,
         )
 
-    price_totals: dict[str, float] = {}
+    price_totals: dict[str, Decimal] = {}
     if price_definitions:
         price_totals = await _collect_price_statistics(
             hass,
@@ -1609,17 +1610,107 @@ async def _collect_statistics(
     return StatisticsResult(stats_map, metadata)
 
 
+_DECIMAL_ZERO = Decimal("0")
+
+
+def _normalize_statistic_value(value: Any) -> Decimal | None:
+    """Convertir une valeur de statistique en décimal exploitable."""
+
+    if value is None:
+        return None
+
+    if isinstance(value, Decimal):
+        decimal_value = value
+    else:
+        try:
+            decimal_value = Decimal(str(value))
+        except (InvalidOperation, TypeError, ValueError):
+            return None
+
+    if not decimal_value.is_finite():
+        return None
+
+    return decimal_value
+
+
+def _select_counter_total(row: StatisticsRow) -> Decimal | None:
+    """Choisir la contribution quotidienne à partir d'une ligne de statistiques."""
+
+    change_value = _normalize_statistic_value(row.get("change"))
+    sum_value = _normalize_statistic_value(row.get("sum"))
+
+    if change_value is not None:
+        if change_value > 0:
+            return change_value
+
+        if change_value == 0:
+            # Aucune variation détectée; un sum positif peut encore refléter la
+            # consommation réelle si le compteur s'est remis à zéro.
+            if sum_value is not None and sum_value > 0:
+                return sum_value
+            return _DECIMAL_ZERO
+
+        # change négatif → privilégier un sum positif, sinon utiliser l'absolu
+        if sum_value is not None and sum_value > 0:
+            return sum_value
+        return change_value.copy_abs()
+
+    if sum_value is None:
+        return None
+
+    if sum_value >= 0:
+        return sum_value
+
+    return sum_value.copy_abs()
+
+
+def _row_starts_before(row: StatisticsRow, end: datetime) -> bool:
+    """Vérifier que la ligne appartient bien à la fenêtre demandée."""
+
+    row_start: Any = getattr(row, "start", None)
+    if row_start is None and isinstance(row, Mapping):
+        row_start = row.get("start")
+
+    if row_start is None:
+        return True
+
+    if isinstance(row_start, str):
+        parsed = dt_util.parse_datetime(row_start)
+        if parsed is None:
+            return True
+        row_start = parsed
+
+    if isinstance(row_start, datetime):
+        if row_start.tzinfo is None:
+            row_start = row_start.replace(tzinfo=dt_util.UTC)
+        else:
+            row_start = dt_util.as_utc(row_start)
+
+        return row_start < end
+
+    return True
+
+
+def _normalize_total_value(value: Any) -> Decimal:
+    """Garantir une valeur décimale exploitable pour les totaux cumulés."""
+
+    normalized = _normalize_statistic_value(value)
+    if normalized is None:
+        return _DECIMAL_ZERO
+    return normalized
+
+
 async def _collect_co2_statistics(
     hass: HomeAssistant,
     start: datetime,
     end: datetime,
     sensors: Iterable[CO2SensorDefinition],
-) -> dict[str, float]:
+) -> dict[str, Decimal]:
     """Assembler les totaux CO₂ sur la période demandée."""
 
     definitions = list(sensors)
-    results: dict[str, float] = {
-        definition.translation_key: 0.0 for definition in definitions
+    results: dict[str, Decimal] = {
+        definition.translation_key: _DECIMAL_ZERO for definition in definitions
     }
 
     if not definitions:
@@ -1638,7 +1729,7 @@ async def _collect_co2_statistics(
         statistic_ids,
         "day",
         None,
-        {"change"},
+        {"change", "sum"},
     )
 
     for entity_id in statistic_ids:
@@ -1646,14 +1737,16 @@ async def _collect_co2_statistics(
         if not rows:
             continue
 
-        total = 0.0
+        total = Decimal("0")
         has_sum = False
         for row in rows:
-            change_value = row.get("change")
-            if change_value is None:
+            if not _row_starts_before(row, end):
+                continue
+            contribution = _select_counter_total(row)
+            if contribution is None:
                 continue
             has_sum = True
-            total += float(change_value)
+            total += contribution
 
         if has_sum:
             definition = entity_map[entity_id]
@@ -1667,12 +1760,12 @@ async def _collect_price_statistics(
     start: datetime,
     end: datetime,
     sensors: Iterable[PriceSensorDefinition],
-) -> dict[str, float]:
+) -> dict[str, Decimal]:
     """Assembler les totaux financiers sur la période demandée."""
 
     definitions = list(sensors)
-    results: dict[str, float] = {
-        definition.translation_key: 0.0 for definition in definitions
+    results: dict[str, Decimal] = {
+        definition.translation_key: _DECIMAL_ZERO for definition in definitions
     }
 
     if not definitions:
@@ -1691,7 +1784,7 @@ async def _collect_price_statistics(
         statistic_ids,
         "day",
         None,
-        {"change"},
+        {"change", "sum"},
     )
 
     for entity_id in statistic_ids:
@@ -1699,14 +1792,16 @@ async def _collect_price_statistics(
         if not rows:
             continue
 
-        total = 0.0
+        total = Decimal("0")
         has_sum = False
         for row in rows:
-            change_value = row.get("change")
-            if change_value is None:
+            if not _row_starts_before(row, end):
+                continue
+            contribution = _select_counter_total(row)
+            if contribution is None:
                 continue
             has_sum = True
-            total += float(change_value)
+            total += contribution
 
         if has_sum:
             definition = entity_map[entity_id]
@@ -1823,10 +1918,10 @@ def _build_pdf(
     translations: ReportTranslations,
 
     co2_definitions: Iterable[CO2SensorDefinition],
-    co2_totals: dict[str, float],
+    co2_totals: Mapping[str, Decimal],
 
     price_definitions: Iterable[PriceSensorDefinition],
-    price_totals: dict[str, float],
+    price_totals: Mapping[str, Decimal],
 
     advice_text: str,
     conclusion_summary: ConclusionSummary | None = None,
@@ -2005,11 +2100,13 @@ def _build_pdf(
         builder.add_paragraph(translations.price_section_intro)
 
         price_rows: list[tuple[str, str, str]] = []
-        expenses_total = 0.0
-        income_total = 0.0
+        expenses_total = Decimal("0")
+        income_total = Decimal("0")
 
         for definition in price_definitions:
-            value = price_totals_map.get(definition.translation_key, 0.0)
+            value = _normalize_total_value(
+                price_totals_map.get(definition.translation_key, _DECIMAL_ZERO)
+            )
             label = translations.price_sensor_labels.get(
                 definition.translation_key, definition.translation_key
             )
@@ -2048,8 +2145,8 @@ def _build_pdf(
 
     totals_map = co2_totals or {}
     co2_rows: list[tuple[str, str, str]] = []
-    emissions_total = 0.0
-    savings_total = 0.0
+    emissions_total = Decimal("0")
+    savings_total = Decimal("0")
 
 
     if co2_definitions:
@@ -2057,11 +2154,13 @@ def _build_pdf(
         builder.add_paragraph(translations.co2_section_intro)
 
         co2_rows: list[tuple[str, str, str]] = []
-        emissions_total = 0.0
-        savings_total = 0.0
+        emissions_total = Decimal("0")
+        savings_total = Decimal("0")
 
         for definition in co2_definitions:
-            value = totals_map.get(definition.translation_key, 0.0)
+            value = _normalize_total_value(
+                totals_map.get(definition.translation_key, _DECIMAL_ZERO)
+            )
             label = translations.co2_sensor_labels.get(
                 definition.translation_key, definition.translation_key
             )
@@ -2658,23 +2757,49 @@ def _safe_float(value: Any) -> float | None:
         return None
 
 
-def _format_number(value: float) -> str:
+def _format_number(value: Decimal | float) -> str:
     """Formater une valeur numérique de manière lisible."""
 
-    if abs(value) < 0.0005:
-        value = 0.0
+    magnitude = float(abs(value))
+    if magnitude < 0.0005:
+        return "0"
 
-    if abs(value) >= 1000:
+    if magnitude >= 1000:
         formatted = f"{value:,.0f}"
-    elif abs(value) >= 10:
+    elif magnitude >= 10:
         formatted = f"{value:,.1f}"
-    else:
+    elif magnitude >= 1:
         formatted = f"{value:,.3f}"
+    else:
+        return _format_small_decimal(value)
 
     return formatted.replace(",", " ")
 
 
-def _format_with_unit(value: float, unit: str | None) -> str:
+def _format_small_decimal(value: Decimal | float) -> str:
+    """Conserver la précision des petites valeurs sans les arrondir."""
+
+    if isinstance(value, Decimal):
+        decimal_value = value
+    else:
+        try:
+            decimal_value = Decimal(str(value))
+        except (InvalidOperation, TypeError, ValueError):
+            decimal_value = Decimal("0")
+
+    normalized = decimal_value.normalize()
+    formatted = format(normalized, "f")
+
+    if "." in formatted:
+        formatted = formatted.rstrip("0").rstrip(".")
+
+    if not formatted or formatted in {"0", "-0", "0.0", "-0.0"}:
+        return "0"
+
+    return formatted
+
+
+def _format_with_unit(value: Decimal | float, unit: str | None) -> str:
     """Associer un formatage numérique avec une unité si disponible."""
 
     formatted = _format_number(value)


### PR DESCRIPTION
## Summary
- switch CO₂ and price aggregations to decimal arithmetic so recorder statistics are summed without rounding
- propagate the decimal totals through PDF rendering and update number formatting to preserve small values
- document the decimal accumulation workflow for tiny CO₂/price counters in both READMEs

## Testing
- python -m compileall custom_components/energy_pdf_report/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68ea8a8e58b08320aa25026fe964ae20