### PR TITLE
Fix CO₂ statistics aggregation to sum daily totals

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -1730,7 +1730,7 @@ async def _collect_co2_statistics(
         statistic_ids,
         "day",
         None,
-        {"change", "sum"},
+        {"sum"},
     )
 
     for entity_id in statistic_ids:
@@ -1743,11 +1743,11 @@ async def _collect_co2_statistics(
         for row in rows:
             if not _row_starts_before(row, end):
                 continue
-            contribution = _select_counter_total(row)
-            if contribution is None:
+            sum_value = _normalize_statistic_value(row.get("sum"))
+            if sum_value is None:
                 continue
             has_sum = True
-            total += contribution
+            total += sum_value
 
         if has_sum:
             definition = entity_map[entity_id]


### PR DESCRIPTION
## Summary
- sum the daily `sum` statistics for CO₂ sensors instead of applying change-based logic
- ensure aggregated CO₂ totals match the Home Assistant history display

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ebd4cb75508320bc831093524181ed