### PR TITLE
Fix CO2 total sensors aggregation by day

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -1791,6 +1791,9 @@ async def _collect_co2_statistics(
             state_class_obj = meta_entry[1].get("state_class")
             if isinstance(state_class_obj, str):
                 state_class = state_class_obj
+        daily_totals: dict[date, Decimal] | None = None
+        if state_class == "total":
+            daily_totals = {}
         for row in rows:
             if not _row_starts_before(row, end):
                 continue
@@ -1798,8 +1801,25 @@ async def _collect_co2_statistics(
                 sum_value = _normalize_statistic_value(row.get("sum"))
                 if sum_value is None:
                     continue
+                row_start: Any = getattr(row, "start", None)
+                if row_start is None and isinstance(row, Mapping):
+                    row_start = row.get("start")
+                row_start_dt: datetime | None
+                if isinstance(row_start, str):
+                    row_start_dt = dt_util.parse_datetime(row_start)
+                elif isinstance(row_start, datetime):
+                    row_start_dt = row_start
+                else:
+                    row_start_dt = None
+                if row_start_dt is None:
+                    continue
+                if row_start_dt.tzinfo is None:
+                    row_start_dt = row_start_dt.replace(tzinfo=dt_util.UTC)
+                day_key = dt_util.as_local(row_start_dt).date()
+                existing = daily_totals.get(day_key)
+                if existing is None or sum_value > existing:
+                    daily_totals[day_key] = sum_value
                 has_sum = True
-                total += sum_value
                 continue
 
             contribution = _select_counter_total(row)
@@ -1807,6 +1827,10 @@ async def _collect_co2_statistics(
                 continue
             has_sum = True
             total += contribution
+
+        if state_class == "total" and daily_totals:
+            total = sum(daily_totals.values(), Decimal("0"))
+            has_sum = True
 
         if has_sum:
             definition = entity_map[entity_id]


### PR DESCRIPTION
## Summary
- group daily statistics for state_class `total` CO₂ sensors and use the maximum daily sum before aggregating
- keep the existing total_increasing aggregation path unchanged

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ebdba8ecb483208be3d6894ebf2391