### PR TITLE
Fix CO₂ state class detection

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -1785,12 +1785,24 @@ async def _collect_co2_statistics(
 
         total = Decimal("0")
         has_sum = False
-        meta_entry = metadata.get(entity_id)
         state_class: str | None = None
-        if meta_entry:
-            state_class_obj = meta_entry[1].get("state_class")
-            if isinstance(state_class_obj, str):
-                state_class = state_class_obj
+
+        state_obj = hass.states.get(entity_id)
+        if state_obj is not None:
+            state_class_attr = state_obj.attributes.get("state_class")
+            if not isinstance(state_class_attr, str):
+                state_class_attr = getattr(state_class_attr, "value", state_class_attr)
+            if isinstance(state_class_attr, str):
+                state_class = state_class_attr
+
+        if state_class is None:
+            meta_entry = metadata.get(entity_id)
+            if meta_entry:
+                state_class_obj = meta_entry[1].get("state_class")
+                if not isinstance(state_class_obj, str):
+                    state_class_obj = getattr(state_class_obj, "value", state_class_obj)
+                if isinstance(state_class_obj, str):
+                    state_class = state_class_obj
 
         daily_totals: dict[date, Decimal] | None = None
         if state_class == "total":


### PR DESCRIPTION
## Summary
- resolve CO₂ total detection by preferring the live entity state_class and falling back to recorder metadata, including enum values so sensors without metadata still classify correctly
- ensure daily total sensors like water accumulate using daily sums while retaining counter logic for cumulative sensors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ebe08437c88320adb562bec3afd916