### PR TITLE
Use previous week/month period defaults

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -1196,9 +1196,14 @@ def _resolve_period(
         if period == "day":
             start_date = now_local.date()
         elif period == "week":
-            start_date = (now_local - timedelta(days=now_local.weekday())).date()
+            start_date = (
+                now_local - timedelta(days=now_local.weekday() + 7)
+            ).date()
         elif period == "month":
-            start_date = now_local.replace(day=1).date()
+            previous_month_start = (
+                (now_local.replace(day=1) - timedelta(days=1)).replace(day=1)
+            )
+            start_date = previous_month_start.date()
         else:
             raise HomeAssistantError("Période non supportée")
 


### PR DESCRIPTION
## Summary
- default automatically selected weekly reports to the previous full week when no dates are supplied
- default monthly reports to the previous full month so generated periods always contain data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ed1afc2e348320b6c72e5946cab554