### PR TITLE
Refine period resolution and unify CO₂/price aggregation

### DIFF
--- a/custom_components/energy_pdf_report/const.py
+++ b/custom_components/energy_pdf_report/const.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 DOMAIN = "energy_pdf_report"
 SERVICE_GENERATE_REPORT = "generate"
 DEFAULT_PERIOD = "day"
-VALID_PERIODS: tuple[str, ...] = ("day", "week", "month")
+VALID_PERIODS: tuple[str, ...] = ("day", "week", "month", "custom")
 
 DEFAULT_REPORT_TYPE = "week"
 


### PR DESCRIPTION
## Summary
- ensure period resolution always uses the Home Assistant timezone and treats custom ranges with the same exclusive end handling as preset ranges
- add shared helpers for CO₂ and price statistics so daily totals are summed deterministically with end-exclusive filtering
- allow the `custom` period option to flow through the existing resolution path

## Testing
- python -m compileall custom_components/energy_pdf_report

------
https://chatgpt.com/codex/tasks/task_e_68ed2b3b95ec8320b36e2126cedd1d30