### PR TITLE
Ensure exclusive end filtering for sensor totals

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -1562,7 +1562,9 @@ def _extract_row_total(row: Mapping[str, Any] | StatisticsRow) -> float | None:
 
 
 def _sum_daily_totals(
-    rows: Iterable[Mapping[str, Any] | StatisticsRow], timezone: tzinfo
+    rows: Iterable[Mapping[str, Any] | StatisticsRow],
+    timezone: tzinfo,
+    end: datetime,
 ) -> dict[date, float]:
     """Construire le total quotidien maximum pour chaque journée locale."""
 
@@ -1570,6 +1572,9 @@ def _sum_daily_totals(
     daily_changes: defaultdict[date, float] = defaultdict(float)
 
     for row in rows:
+        if not _row_starts_before(row, end, timezone):
+            continue
+
         start_dt = _parse_row_datetime(_row_value(row, "start"), timezone)
         if start_dt is None:
             continue
@@ -1650,7 +1655,7 @@ async def _collect_totals_for_sensors(
         if not rows_list:
             continue
 
-        daily_max_sums = _sum_daily_totals(rows_list, timezone)
+        daily_max_sums = _sum_daily_totals(rows_list, timezone, end)
         if not daily_max_sums:
             continue
 


### PR DESCRIPTION
## Summary
- ensure `_sum_daily_totals` skips statistics rows that begin at or after the exclusive period end
- pass the exclusive end to the daily total aggregation used by CO₂ and price collectors

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ed37fcd0d48320b66af163ecf597d2