### PR TITLE
Fix NameError when resolving custom reporting period

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -1306,6 +1306,9 @@ def _resolve_period(
 
     timezone = _select_timezone(hass)
 
+    start_date = _coerce_service_date(call_data.get(CONF_START_DATE), CONF_START_DATE)
+    end_date = _coerce_service_date(call_data.get(CONF_END_DATE), CONF_END_DATE)
+
     normalized_period = (period or "").strip().lower() or None
 
     start_utc, end_utc = resolve_reporting_period(hass, period, start_date, end_date)


### PR DESCRIPTION
## Summary
- coerce the optional start and end dates from the service payload
- prevent the reporting period resolver from raising a NameError when custom dates are provided

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ee089acc0c8320ab7177e6b0fbcd5b