### PR TITLE
Ensure _resolve_period defines custom date inputs

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -1306,6 +1306,12 @@ def _resolve_period(
 
     timezone = _select_timezone(hass)
 
+    start_date_raw = call_data.get(CONF_START_DATE)
+    end_date_raw = call_data.get(CONF_END_DATE)
+
+    start_date = _coerce_service_date(start_date_raw, CONF_START_DATE)
+    end_date = _coerce_service_date(end_date_raw, CONF_END_DATE)
+
     normalized_period = (period or "").strip().lower() or None
 
     start_utc, end_utc = resolve_reporting_period(hass, period, start_date, end_date)
@@ -1321,8 +1327,6 @@ def _resolve_period(
 
     display_start_local = start_local
     display_end_local = end_local_exclusive - timedelta(seconds=1)
-
-    bucket_period = period if start_date is None and end_date is None else "custom"
 
     return (
         start_utc,


### PR DESCRIPTION
## Summary
- read the raw start and end dates from the service payload before coercing them
- ensure `_resolve_period` always defines the custom date arguments passed to `resolve_reporting_period`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ee089acc0c8320ab7177e6b0fbcd5b