### PR TITLE
Select last completed period by default

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -1194,11 +1194,14 @@ def _resolve_period(
 
     if start_date is None:
         if period == "day":
-            start_date = now_local.date()
+            start_date = (now_local - timedelta(days=1)).date()
         elif period == "week":
-            start_date = (now_local - timedelta(days=now_local.weekday())).date()
+            start_date = (
+                now_local - timedelta(days=now_local.weekday() + 7)
+            ).date()
         elif period == "month":
-            start_date = now_local.replace(day=1).date()
+            first_of_current_month = now_local.replace(day=1)
+            start_date = (first_of_current_month - timedelta(days=1)).replace(day=1).date()
         else:
             raise HomeAssistantError("Période non supportée")
 


### PR DESCRIPTION
## Summary
- ensure automatically inferred periods use the most recent fully completed range in the past

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ee2b5f87a08320bff980e9959933a8